### PR TITLE
Fix and improve estimate standardization

### DIFF
--- a/inst/qml/ClassicProcess.qml
+++ b/inst/qml/ClassicProcess.qml
@@ -421,18 +421,25 @@ Form
     Section
     {
         title: qsTr("Options")
-        columns: 2
+        columns: 3
 
-		GroupBox
+		Group
 		{
 			CheckBox { label: qsTr("Parameter labels") 	;		name: "parameterLabels" }
-			CheckBox { label: qsTr("Standardized estimates") ;  name: "standardizedEstimates" }
 			CheckBox { label: qsTr("Lavaan syntax")     ;       name: "syntax" }
 			CheckBox { label: qsTr("R-squared")         ;       name: "rSquared" }
 			CheckBox { label: qsTr("AIC weights")         ;     name: "aicWeights" }
 			CheckBox { label: qsTr("BIC weights")         ;     name: "bicWeights" }
 		}
-        GroupBox
+		RadioButtonGroup
+		{
+			name: "standardizedEstimates"
+			title: qsTr("Standardized estimates")
+			RadioButton { value: "unstandardized"; label: qsTr("Unstandardized"); checked: true }
+			RadioButton { value: "centered"; label: qsTr("Mean-centered") }
+			RadioButton { value: "standardized"; label: qsTr("Standardized") }
+		}
+        Group
         {
             CIField {
                 text: qsTr("Confidence intervals")


### PR DESCRIPTION
Changes the way estimates are standardized:

- Now, three options are available: Unstandardized, mean-centered, standardized
- All variables are standardized before any other computations are made (including three way interactions)
- For listwise missing value deletion, only compute scaling based on complete cases; because listwise handling deletes incomplete cases, otherwise the the variables used by lavaan would not be correctly standardized anymore
- Adds a footnote indicating that estimates etc. are standardized
- Fixes a bug for calculating dummy variables with missing values